### PR TITLE
feat: reaffirming Eludris' support for `ggVG` users

### DIFF
--- a/src/routes/(logged_in)/+layout.server.ts
+++ b/src/routes/(logged_in)/+layout.server.ts
@@ -10,7 +10,8 @@ const facts = [
   'Eludris is factually better than Disco- well, maybe not yet',
   'I am the storm that is approaching',
   'Coffee is kinda pog',
-  'The name pengin originally started as a joke about linux users while watching <a href="https://cdn.eludris.gay/static/pengin.mp4" target="_blank">this video</a> on loop'
+  'The name pengin originally started as a joke about linux users while watching <a href="https://cdn.eludris.gay/static/pengin.mp4" target="_blank">this video</a> on loop',
+  'ggVG is a sensible keybind.'
 ];
 
 export function load() {


### PR DESCRIPTION
I've felt the obligation to make this PR in order to reaffirm the seemingly unnoticed support of Eludris for world-wide users of the vim `ggVG` keybind.

Whatever you do, and whether you agree or not, please do not add the `invalid` label to this PR.